### PR TITLE
Support user detail returning and permission assignment with sub organizations

### DIFF
--- a/org.wso2.carbon.identity.organization.mgt.core/pom.xml
+++ b/org.wso2.carbon.identity.organization.mgt.core/pom.xml
@@ -113,6 +113,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.event</artifactId>
         </dependency>
     </dependencies>

--- a/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/OrganizationManagerImpl.java
+++ b/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/OrganizationManagerImpl.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.organization.mgt.core.dao.CacheBackedOrganizationMgtDAO;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
@@ -139,6 +140,8 @@ public class OrganizationManagerImpl implements OrganizationManager {
     private OrganizationMgtDao organizationMgtDao = OrganizationMgtDataHolder.getInstance().getOrganizationMgtDao();
     private OrganizationAuthorizationDao authorizationDao = OrganizationMgtDataHolder.getInstance()
             .getOrganizationAuthDao();
+    private CacheBackedOrganizationMgtDAO cacheBackedOrganizationMgtDAO =
+            OrganizationMgtDataHolder.getInstance().getCacheBackedOrganizationMgtDAO();
 
     @Override
     public Organization addOrganization(OrganizationAdd organizationAdd, boolean isImport)
@@ -173,7 +176,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
                 log.debug("Creating LDAP subdirectory for the organization id : " + organization.getId());
             }
         }
-        organizationMgtDao.addOrganization(getTenantId(), organization);
+        cacheBackedOrganizationMgtDAO.addOrganization(getTenantId(), organization);
         grantCreatorWithFullPermission(organization.getId());
         // Fire post-event
         event = isImport ? POST_IMPORT_ORGANIZATION : POST_CREATE_ORGANIZATION;
@@ -307,7 +310,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
             throw handleClientException(ERROR_CODE_INVALID_ORGANIZATION_DELETE_REQUEST,
                     "Organization " + organizationId + " is not in the disabled status");
         }
-        organizationMgtDao.deleteOrganization(getTenantId(), organizationId.trim());
+        cacheBackedOrganizationMgtDAO.deleteOrganization(getTenantId(), organizationId.trim());
         // Fire post-event
         fireEvent(POST_DELETE_ORGANIZATION, organizationId, null, Status.SUCCESS);
     }

--- a/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/cache/OrganizationCache.java
+++ b/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/cache/OrganizationCache.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.mgt.core.cache;
+
+import org.wso2.carbon.identity.application.common.cache.BaseCache;
+import org.wso2.carbon.utils.CarbonUtils;
+
+/**
+ * Cache implementation for organization's children cache.
+ */
+public class OrganizationCache extends BaseCache<OrganizationCacheKey, OrganizationCacheEntry> {
+
+    private static final String CACHE_NAME = "OrgChildrenCacheById";
+
+    private static final OrganizationCache instance = new OrganizationCache();
+
+    private OrganizationCache() {
+
+        super(CACHE_NAME);
+    }
+
+    public static OrganizationCache getInstance() {
+
+        CarbonUtils.checkSecurity();
+        return instance;
+    }
+}

--- a/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/cache/OrganizationCacheEntry.java
+++ b/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/cache/OrganizationCacheEntry.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.mgt.core.cache;
+
+import org.wso2.carbon.identity.application.common.cache.CacheEntry;
+
+import java.util.List;
+
+/**
+ * Cache entry which is kept in the children organizations.
+ */
+public class OrganizationCacheEntry extends CacheEntry {
+
+    private static final long serialVersionUID = 3112605038259278777L;
+
+    private List<String> childrenOrganizations;
+
+    public OrganizationCacheEntry(List<String> childrenOrganizations) {
+
+        this.childrenOrganizations = childrenOrganizations;
+    }
+
+    public List<String> getChildrenOrganizations() {
+
+        return childrenOrganizations;
+    }
+
+    public void setChildrenOrganizations(List<String> childrenOrganizations) {
+
+        this.childrenOrganizations = childrenOrganizations;
+    }
+}

--- a/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/cache/OrganizationCacheKey.java
+++ b/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/cache/OrganizationCacheKey.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.mgt.core.cache;
+
+import org.wso2.carbon.identity.application.common.cache.CacheKey;
+
+/**
+ * Cache key for lookup organization's children from the cache.
+ */
+public class OrganizationCacheKey extends CacheKey {
+
+    private static final long serialVersionUID = 8263255365985309443L;
+
+    private String organizationKey;
+
+    public OrganizationCacheKey(String organizationId) {
+
+        this.organizationKey = organizationId;
+    }
+
+    public String getOrganizationKey() {
+
+        return organizationKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        OrganizationCacheKey that = (OrganizationCacheKey) o;
+
+        if (!organizationKey.equals(that.organizationKey)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+
+        int result = super.hashCode();
+        result = 31 * result + organizationKey.hashCode();
+        return result;
+    }
+
+}

--- a/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/constant/SQLConstants.java
+++ b/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/constant/SQLConstants.java
@@ -92,11 +92,13 @@ public class SQLConstants {
     public static final String VIEW_CONFIG_KEY_COLUMN = "CONFIG_KEY";
     public static final String VIEW_CONFIG_VALUE_COLUMN = "CONFIG_VALUE";
     public static final String UM_ROLE_ID_COLUMN = "UM_ROLE_ID";
+    public static final String UM_UM_USER_ID_COLUMN = "UM_USER_ID";
     public static final String UM_HYBRID_ROLE_ID_COLUMN = "UM_HYBRID_ROLE_ID";
     public static final String UM_RESOURCE_ID_COLUMN = "UM_RESOURCE_ID";
 
     public static final String UM_ID_COLUMN = "UM_ID";
     public static final String ATTR_VALUE_COLUMN = "ATTR_VALUE";
+    public static final String INSERT_ALL = "INSERT ALL ";
 
     public static final String LIKE_SYMBOL = "%";
     public static final String COLUMN_LOWER_WRAPPER = "lower(%s)";
@@ -295,4 +297,15 @@ public class SQLConstants {
             "    ORG_AUTHZ_VIEW\n" +
             "WHERE\n" +
             "    UM_USER_ID = ? AND ORG_ID IN (#)";
+    public static final String GET_USER_ROLE_ORG_MAPPINGS_FOR_GIVEN_ORG =
+            "SELECT\n" +
+            "    UM_USER_ID, UM_ROLE_ID, UM_HYBRID_ROLE_ID\n" +
+            "FROM\n" +
+            "    UM_USER_ROLE_ORG\n" +
+            "WHERE\n" +
+            "    ORG_ID = ? AND UM_TENANT_ID = ?";
+    public static final String INSERT_INTO_ORGANIZATION_USER_ROLE_MAPPING =
+            "INTO UM_USER_ROLE_ORG (UM_ID, UM_USER_ID, UM_ROLE_ID, UM_HYBRID_ROLE_ID, UM_TENANT_ID, ORG_ID) " +
+                    "VALUES (?, ?, ?, ?, ?, ?) ";
+    public static final String SELECT_DUMMY_RECORD = "SELECT 1 FROM DUAL";
 }

--- a/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/dao/CacheBackedOrganizationMgtDAO.java
+++ b/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/dao/CacheBackedOrganizationMgtDAO.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.mgt.core.dao;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.organization.mgt.core.cache.OrganizationCache;
+import org.wso2.carbon.identity.organization.mgt.core.cache.OrganizationCacheEntry;
+import org.wso2.carbon.identity.organization.mgt.core.cache.OrganizationCacheKey;
+import org.wso2.carbon.identity.organization.mgt.core.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.mgt.core.model.Metadata;
+import org.wso2.carbon.identity.organization.mgt.core.model.Operation;
+import org.wso2.carbon.identity.organization.mgt.core.model.Organization;
+import org.wso2.carbon.identity.organization.mgt.core.model.UserStoreConfig;
+import org.wso2.carbon.identity.organization.mgt.core.search.Condition;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Cached organization tree nodes for organization management.
+ */
+public class CacheBackedOrganizationMgtDAO implements OrganizationMgtDao {
+
+    private static final Log log = LogFactory.getLog(CacheBackedOrganizationMgtDAO.class);
+
+    private OrganizationMgtDao organizationMgtDao = null;
+    private OrganizationCache organizationCache = null;
+
+    public CacheBackedOrganizationMgtDAO(OrganizationMgtDao organizationMgtDao) {
+
+        this.organizationMgtDao = organizationMgtDao;
+        organizationCache = OrganizationCache.getInstance();
+
+    }
+
+    @Override
+    public void addOrganization(int tenantId, Organization organization) throws OrganizationManagementException {
+
+        // Remove cache for the parent organization of the adding org
+        String parentOrgId = organization.getParent().getId();
+        // Parent id can be null if it is the root. We are adding root as an org (verify later)
+        if (log.isDebugEnabled()) {
+            log.debug("Removing entry for  Organization: " + parentOrgId + " from cache");
+        }
+        clearOrganizationCache(tenantId, parentOrgId);
+        organizationMgtDao.addOrganization(tenantId, organization);
+    }
+
+    @Override
+    public void deleteOrganization(int tenantId, String organizationId) throws OrganizationManagementException {
+
+        Organization orgToBeDeleted = organizationMgtDao.getOrganization(tenantId, organizationId);
+        if (orgToBeDeleted != null) {
+            String parentId = orgToBeDeleted.getParent().getId();
+            // Clear the children cache for this orgId.
+            if (log.isDebugEnabled()) {
+                log.debug("Removing entry for  Organization: " + organizationId + " from cache");
+            }
+            clearOrganizationCache(tenantId, organizationId);
+            // Clear the children cache for parent of this orgId.
+            if (log.isDebugEnabled()) {
+                log.debug("Removing entry for  Organization: " + parentId + " from cache");
+            }
+            clearOrganizationCache(tenantId, parentId);
+        }
+        organizationMgtDao.deleteOrganization(tenantId, organizationId);
+    }
+
+    @Override
+    public boolean isOrganizationExistByName(int tenantId, String name) throws OrganizationManagementException {
+
+        return organizationMgtDao.isOrganizationExistByName(tenantId, name);
+    }
+
+    @Override
+    public boolean isOrganizationExistById(int tenantId, String id) throws OrganizationManagementException {
+
+        OrganizationCacheKey cacheKey = new OrganizationCacheKey(id);
+        OrganizationCacheEntry entry = organizationCache.getValueFromCache(cacheKey);
+
+        if (entry != null) {
+            return true;
+        }
+        return organizationMgtDao.isOrganizationExistById(tenantId, id);
+    }
+
+    @Override
+    public Organization getOrganization(int tenantId, String organizationId) throws OrganizationManagementException {
+
+        return organizationMgtDao.getOrganization(tenantId, organizationId);
+    }
+
+    @Override
+    public String getOrganizationIdByName(int tenantId, String organizationName)
+            throws OrganizationManagementException {
+
+        return organizationMgtDao.getOrganizationIdByName(tenantId, organizationName);
+    }
+
+    @Override
+    public List<Organization> getOrganizations(Condition condition, int tenantId, int offset, int limit, String sortBy,
+                                               String sortOrder, List<String> requestedAttributes, String userId,
+                                               boolean includePermissions) throws OrganizationManagementException {
+
+        return organizationMgtDao
+                .getOrganizations(condition, tenantId, offset, limit, sortBy, sortOrder, requestedAttributes, userId,
+                        includePermissions);
+    }
+
+    @Override
+    public Map<String, UserStoreConfig> getUserStoreConfigsByOrgId(int tenantId, String organizationId)
+            throws OrganizationManagementException {
+
+        return organizationMgtDao.getUserStoreConfigsByOrgId(tenantId, organizationId);
+    }
+
+    @Override
+    public List<String> getChildOrganizationIds(String organizationId, String userId)
+            throws OrganizationManagementException {
+
+        OrganizationCacheKey cacheKey = new OrganizationCacheKey(organizationId);
+        OrganizationCacheEntry entry = organizationCache.getValueFromCache(cacheKey);
+
+        if (entry != null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache entry found for organization id: " + organizationId);
+            }
+            List<String> childrenOrgs = entry.getChildrenOrganizations();
+            return childrenOrgs;
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Fetching entry from DB because cache entry not found for organization id: " + organizationId);
+            }
+        }
+
+        List<String> childrenOrgs = organizationMgtDao.getChildOrganizationIds(organizationId, null);
+        if (childrenOrgs != null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Entry fetched from the database for organization: " + organizationId + ". Updating cache");
+            }
+            organizationCache.addToCache(cacheKey, new OrganizationCacheEntry(childrenOrgs));
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Children organizations for organization with id " + organizationId +
+                        " not found in cache or DB.");
+            }
+        }
+        return childrenOrgs;
+    }
+
+    @Override
+    public void patchOrganization(String organizationId, Operation operation) throws OrganizationManagementException {
+
+        //TODO if Parent is changing impact for the cache. Otherwise no issue.
+        organizationMgtDao.patchOrganization(organizationId, operation);
+    }
+
+    @Override
+    public void patchUserStoreConfigs(String organizationId, Operation operation)
+            throws OrganizationManagementException {
+
+        organizationMgtDao.patchUserStoreConfigs(organizationId, operation);
+    }
+
+    @Override
+    public boolean isAttributeExistByKey(int tenantId, String organizationId, String attributeKey)
+            throws OrganizationManagementException {
+
+        return organizationMgtDao.isAttributeExistByKey(tenantId, organizationId, attributeKey);
+    }
+
+    @Override
+    public void modifyOrganizationMetadata(String organizationId, Metadata metadata)
+            throws OrganizationManagementException {
+
+        organizationMgtDao.modifyOrganizationMetadata(organizationId, metadata);
+    }
+
+    @Override
+    public boolean isRdnAvailable(String rdn, String parentId, int tenantId) throws OrganizationManagementException {
+
+        return organizationMgtDao.isRdnAvailable(rdn, parentId, tenantId);
+    }
+
+    private void clearOrganizationCache(int tenantId, String organizationId) throws OrganizationManagementException {
+
+        // TODO whether we have to check children list ??
+        Organization organization = this.getOrganization(tenantId, organizationId);
+        if (organization != null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing entry for organization with id " + organizationId + " from cache.");
+            }
+            OrganizationCacheKey cacheKey = new OrganizationCacheKey(organizationId);
+            organizationCache.clearCacheEntry(cacheKey);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Entry for Organization with id " + organizationId + " not found in cache or DB");
+            }
+        }
+    }
+}

--- a/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/dao/OrganizationAuthorizationDao.java
+++ b/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/dao/OrganizationAuthorizationDao.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.organization.mgt.core.dao;
 
 import org.wso2.carbon.database.utils.jdbc.JdbcTemplate;
 import org.wso2.carbon.identity.organization.mgt.core.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.mgt.core.model.OrganizationUserRoleMapping;
 
 import java.util.List;
 import java.util.Map;
@@ -54,7 +55,17 @@ public interface OrganizationAuthorizationDao {
      * @throws OrganizationManagementException
      */
     void addOrganizationAndUserRoleMapping(String userId, String roleId, int hybridRoleId, int tenantId,
-            String organizationId) throws OrganizationManagementException;
+                                           String organizationId) throws OrganizationManagementException;
+
+    /**
+     * Add multiple entries to the 'UM_USER_ROLE_ORG' table.
+     *
+     * @param organizationUserRoleMappings A list of organizationUserRole mappings.
+     * @param tenantID                     Tenant id.
+     * @throws OrganizationManagementException
+     */
+    void addOrganizationAndUserRoleMappings(List<OrganizationUserRoleMapping> organizationUserRoleMappings,
+                                            int tenantID) throws OrganizationManagementException;
 
     /**
      * Find the 'UM_ID' by 'UM_ROLE_NAME' from the 'UM_HYBRID_ROLE' table.
@@ -86,6 +97,18 @@ public interface OrganizationAuthorizationDao {
      * @throws OrganizationManagementException
      */
     Map<String, List<String>> findUserPermissionsForOrganizations(JdbcTemplate template, String userId,
-            List<String> organizationIds)
+                                                                  List<String> organizationIds)
+            throws OrganizationManagementException;
+
+    /**
+     * Get the organization user role mapping for a given organization.
+     *
+     * @param organizationId Organization id.
+     * @param tenantId       Tenant id.
+     * @return A list of organization for the given organization.
+     * @throws OrganizationManagementException
+     */
+    List<OrganizationUserRoleMapping> getOrganizationUserRoleMappingsForOrganization(String organizationId,
+                                                                                     int tenantId)
             throws OrganizationManagementException;
 }

--- a/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/dao/OrganizationAuthorizationDaoImpl.java
+++ b/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/dao/OrganizationAuthorizationDaoImpl.java
@@ -123,6 +123,7 @@ public class OrganizationAuthorizationDaoImpl implements OrganizationAuthorizati
         }
     }
 
+    @SuppressFBWarnings("SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING")
     @Override
     public void addOrganizationAndUserRoleMappings(List<OrganizationUserRoleMapping> organizationUserRoleMappings,
                                                    int tenantID) throws OrganizationManagementServerException {

--- a/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/dao/OrganizationAuthorizationDaoImpl.java
+++ b/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/dao/OrganizationAuthorizationDaoImpl.java
@@ -233,7 +233,7 @@ public class OrganizationAuthorizationDaoImpl implements OrganizationAuthorizati
                                                                                             int tenantId)
             throws OrganizationManagementException {
 
-        JdbcTemplate jdbcTemplate = getNewIdentityTemplate();
+        JdbcTemplate jdbcTemplate = getNewTemplate();
         try {
             return jdbcTemplate.executeQuery(GET_USER_ROLE_ORG_MAPPINGS_FOR_GIVEN_ORG, (resultSet, rowNumber) ->
                             new OrganizationUserRoleMapping(organizationId, resultSet.getString(UM_UM_USER_ID_COLUMN),

--- a/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/internal/OrganizationMgtDataHolder.java
+++ b/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/internal/OrganizationMgtDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.mgt.core.internal;
 
+import org.wso2.carbon.identity.organization.mgt.core.dao.CacheBackedOrganizationMgtDAO;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.organization.mgt.core.dao.OrganizationAuthorizationDao;
 import org.wso2.carbon.identity.organization.mgt.core.dao.OrganizationMgtDao;
@@ -35,6 +36,7 @@ public class OrganizationMgtDataHolder {
     private static final OrganizationMgtDataHolder orgMgtDataHolder = new OrganizationMgtDataHolder();
     private OrganizationAuthorizationDao organizationAuthDao;
     private OrganizationMgtDao organizationMgtDao;
+    private CacheBackedOrganizationMgtDAO cacheBackedOrganizationMgtDAO;
     private RealmService realmService;
     private Map<String, OrganizationMgtRole> organizationMgtRoles = new HashMap<>();
     private IdentityEventService identityEventService;
@@ -70,6 +72,17 @@ public class OrganizationMgtDataHolder {
     public void setOrganizationAuthDao(OrganizationAuthorizationDao organizationAuthDao) {
 
         this.organizationAuthDao = organizationAuthDao;
+    }
+
+    public CacheBackedOrganizationMgtDAO getCacheBackedOrganizationMgtDAO() {
+
+        return cacheBackedOrganizationMgtDAO;
+    }
+
+    public void setCacheBackedOrganizationMgtDAO(
+            CacheBackedOrganizationMgtDAO cacheBackedOrganizationMgtDAO) {
+
+        this.cacheBackedOrganizationMgtDAO = cacheBackedOrganizationMgtDAO;
     }
 
     public RealmService getRealmService() {

--- a/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/internal/OrganizationMgtServiceComponent.java
+++ b/org.wso2.carbon.identity.organization.mgt.core/src/main/java/org/wso2/carbon/identity/organization/mgt/core/internal/OrganizationMgtServiceComponent.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.organization.mgt.core.OrganizationManager;
 import org.wso2.carbon.identity.organization.mgt.core.OrganizationManagerImpl;
+import org.wso2.carbon.identity.organization.mgt.core.dao.CacheBackedOrganizationMgtDAO;
 import org.wso2.carbon.identity.organization.mgt.core.dao.OrganizationAuthorizationDao;
 import org.wso2.carbon.identity.organization.mgt.core.dao.OrganizationAuthorizationDaoImpl;
 import org.wso2.carbon.identity.organization.mgt.core.dao.OrganizationMgtDao;
@@ -85,6 +86,8 @@ public class OrganizationMgtServiceComponent {
         try {
             OrganizationMgtDataHolder.getInstance().setOrganizationMgtDao(new OrganizationMgtDaoImpl());
             OrganizationMgtDataHolder.getInstance().setOrganizationAuthDao(new OrganizationAuthorizationDaoImpl());
+            OrganizationMgtDataHolder.getInstance().setCacheBackedOrganizationMgtDAO(
+                    new CacheBackedOrganizationMgtDAO(OrganizationMgtDataHolder.getInstance().getOrganizationMgtDao()));
             OrganizationMgtDataHolder.getInstance().setOrganizationMgtRoles(populateManagementRoles(-1234));
             BundleContext bundleContext = componentContext.getBundleContext();
             bundleContext.registerService(OrganizationManager.class.getName(), new OrganizationManagerImpl(), null);

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/OrganizationsApi.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/OrganizationsApi.java
@@ -256,7 +256,7 @@ public class OrganizationsApi {
             notes = "This API is used to create user role mappings for an organization.\n",
             response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
-        @io.swagger.annotations.ApiResponse(code = 201, message = "Ok"),
+        @io.swagger.annotations.ApiResponse(code = 201, message = "Created"),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Bad Request"),
         
@@ -301,10 +301,9 @@ public class OrganizationsApi {
     @ApiParam(value = "ID of the role of which, the user will be returned.",required=true ) @PathParam("role-id")  String roleId,
     @ApiParam(value = "Number of items to be skipped before starting to collect the result set. (Should be 0 or positive)") @QueryParam("offset")  Integer offset,
     @ApiParam(value = "Max number of items to be returned. (Should be greater than 0)") @QueryParam("limit")  Integer limit,
-    @ApiParam(value = "Comma separated list of SCIM user attributes to be returned in the response.") @QueryParam("attributes")  String attributes,
-    @ApiParam(value = "Whether the role assigned users in sub organizations will be returned") @QueryParam("includeSubOrgs")  Boolean includeSubOrgs) {
+    @ApiParam(value = "Comma separated list of SCIM user attributes to be returned in the response.") @QueryParam("attributes")  String attributes) {
 
-        return delegate.organizationsOrganizationIdRolesRoleIdUsersGet(organizationId,roleId,offset,limit,attributes,includeSubOrgs);
+        return delegate.organizationsOrganizationIdRolesRoleIdUsersGet(organizationId,roleId,offset,limit,attributes);
     }
 
     @DELETE
@@ -316,7 +315,7 @@ public class OrganizationsApi {
                                          response = void.class)
     @io.swagger.annotations.ApiResponses(value = {
             @io.swagger.annotations.ApiResponse(code = 204,
-                                                message = "Ok"),
+                                                message = "No Content"),
 
             @io.swagger.annotations.ApiResponse(code = 400,
                                                 message = "Bad Request"),

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/OrganizationsApi.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/OrganizationsApi.java
@@ -248,64 +248,26 @@ public class OrganizationsApi {
         return delegate.organizationsOrganizationIdPatch(organizationId, operations);
     }
 
-    @PATCH
-    @Path("/{organization-id}/roles")
-    @Consumes({ "application/json" })
-    @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Modify user role mappings for an organization.\n",
-                                         notes = "This API is used to modify user role mappings for an organization.\n",
-                                         response = void.class)
-    @io.swagger.annotations.ApiResponses(value = {
-            @io.swagger.annotations.ApiResponse(code = 204,
-                                                message = "Ok"),
-
-            @io.swagger.annotations.ApiResponse(code = 400,
-                                                message = "Bad Request"),
-
-            @io.swagger.annotations.ApiResponse(code = 401,
-                                                message = "Unauthorized"),
-
-            @io.swagger.annotations.ApiResponse(code = 500,
-                                                message = "Server Error")
-    })
-
-    public Response organizationsOrganizationIdRolesPatch(
-            @ApiParam(value = "ID of the organization of which, the user role mappings are modified.",
-                      required = true) @PathParam("organization-id") String organizationId,
-            @ApiParam(value = "This represents the patch operation.",
-                      required = true) List<OperationDTO> operations) {
-
-        return delegate.organizationsOrganizationIdRolesPatch(organizationId, operations);
-    }
-
     @POST
     @Path("/{organization-id}/roles")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
     @io.swagger.annotations.ApiOperation(value = "Create a user role mappings for an organization.\n",
-                                         notes = "This API is used to create user role mappings for an organization.\n",
-                                         response = void.class)
-    @io.swagger.annotations.ApiResponses(value = {
-            @io.swagger.annotations.ApiResponse(code = 204,
-                                                message = "Ok"),
+            notes = "This API is used to create user role mappings for an organization.\n",
+            response = void.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 201, message = "Ok"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Bad Request"),
+        
+        @io.swagger.annotations.ApiResponse(code = 401, message = "Unauthorized"),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
 
-            @io.swagger.annotations.ApiResponse(code = 400,
-                                                message = "Bad Request"),
+    public Response organizationsOrganizationIdRolesPost(@ApiParam(value = "ID of the organization of which, the user role mappings are added.",required=true ) @PathParam("organization-id")  String organizationId,
+    @ApiParam(value = "This represents user role mappings." ,required=true ) UserRoleMappingDTO userRoles) {
 
-            @io.swagger.annotations.ApiResponse(code = 401,
-                                                message = "Unauthorized"),
-
-            @io.swagger.annotations.ApiResponse(code = 500,
-                                                message = "Server Error")
-    })
-
-    public Response organizationsOrganizationIdRolesPost(
-            @ApiParam(value = "ID of the organization of which, the user role mappings are added.",
-                      required = true) @PathParam("organization-id") String organizationId,
-            @ApiParam(value = "This represents user role mappings.",
-                      required = true) List<UserRoleMappingDTO> userRoles) {
-
-        return delegate.organizationsOrganizationIdRolesPost(organizationId, userRoles);
+        return delegate.organizationsOrganizationIdRolesPost(organizationId,userRoles);
     }
 
     @GET
@@ -335,13 +297,14 @@ public class OrganizationsApi {
                                                 message = "Server Error")
     })
 
-    public Response organizationsOrganizationIdRolesRoleIdUsersGet(
-            @ApiParam(value = "ID of the organization of which, the users will be returned.",
-                      required = true) @PathParam("organization-id") String organizationId,
-            @ApiParam(value = "ID of the role of which, the user will be returned.",
-                      required = true) @PathParam("role-id") String roleId) {
+    public Response organizationsOrganizationIdRolesRoleIdUsersGet(@ApiParam(value = "ID of the organization of which, the users will be returned.",required=true ) @PathParam("organization-id")  String organizationId,
+    @ApiParam(value = "ID of the role of which, the user will be returned.",required=true ) @PathParam("role-id")  String roleId,
+    @ApiParam(value = "Number of items to be skipped before starting to collect the result set. (Should be 0 or positive)") @QueryParam("offset")  Integer offset,
+    @ApiParam(value = "Max number of items to be returned. (Should be greater than 0)") @QueryParam("limit")  Integer limit,
+    @ApiParam(value = "Comma separated list of SCIM user attributes to be returned in the response.") @QueryParam("attributes")  String attributes,
+    @ApiParam(value = "Whether the role assigned users in sub organizations will be returned") @QueryParam("includeSubOrgs")  Boolean includeSubOrgs) {
 
-        return delegate.organizationsOrganizationIdRolesRoleIdUsersGet(organizationId, roleId);
+        return delegate.organizationsOrganizationIdRolesRoleIdUsersGet(organizationId,roleId,offset,limit,attributes,includeSubOrgs);
     }
 
     @DELETE

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/OrganizationsApi.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/OrganizationsApi.java
@@ -330,15 +330,12 @@ public class OrganizationsApi {
                                                 message = "Server Error")
     })
 
-    public Response organizationsOrganizationIdRolesRoleIdUsersUserIdDelete(
-            @ApiParam(value = "ID of the organization of which, the user role mappings will be deleted.",
-                      required = true) @PathParam("organization-id") String organizationId,
-            @ApiParam(value = "ID of the role of which, the user will be deleted.",
-                      required = true) @PathParam("role-id") String roleId, @ApiParam(value = "ID of the user.",
-                                                                                      required = true) @PathParam(
-                                                                                              "user-id") String userId) {
+    public Response organizationsOrganizationIdRolesRoleIdUsersUserIdDelete(@ApiParam(value = "ID of the organization of which, the user role mappings will be deleted.",required=true ) @PathParam("organization-id")  String organizationId,
+    @ApiParam(value = "ID of the role of which, the user will be deleted.",required=true ) @PathParam("role-id")  String roleId,
+    @ApiParam(value = "ID of the user.",required=true ) @PathParam("user-id")  String userId,
+    @ApiParam(value = "Filter the role mappings to delete. Check whether sub organization's role mappings will be deleted or not.") @QueryParam("includeSubOrgs")  Boolean includeSubOrgs) {
 
-        return delegate.organizationsOrganizationIdRolesRoleIdUsersUserIdDelete(organizationId, roleId, userId);
+        return delegate.organizationsOrganizationIdRolesRoleIdUsersUserIdDelete(organizationId,roleId,userId,includeSubOrgs);
     }
 
     @GET

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/OrganizationsApiService.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/OrganizationsApiService.java
@@ -44,8 +44,7 @@ public abstract class OrganizationsApiService {
 
     public abstract Response organizationsOrganizationIdRolesRoleIdUsersGet(String organizationId, String roleId, Integer offset, Integer limit, String attributes);
 
-    public abstract Response organizationsOrganizationIdRolesRoleIdUsersUserIdDelete(String organizationId,
-            String roleId, String userId);
+    public abstract Response organizationsOrganizationIdRolesRoleIdUsersUserIdDelete(String organizationId, String roleId, String userId, Boolean includeSubOrgs);
 
     public abstract Response organizationsOrganizationIdUsersUserIdRolesGet(String organizationId, String userId);
 

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/OrganizationsApiService.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/OrganizationsApiService.java
@@ -42,7 +42,7 @@ public abstract class OrganizationsApiService {
 
     public abstract Response organizationsOrganizationIdRolesPost(String organizationId, UserRoleMappingDTO userRoles);
 
-    public abstract Response organizationsOrganizationIdRolesRoleIdUsersGet(String organizationId, String roleId, Integer offset, Integer limit, String attributes, Boolean includeSubOrgs);
+    public abstract Response organizationsOrganizationIdRolesRoleIdUsersGet(String organizationId, String roleId, Integer offset, Integer limit, String attributes);
 
     public abstract Response organizationsOrganizationIdRolesRoleIdUsersUserIdDelete(String organizationId,
             String roleId, String userId);
@@ -51,8 +51,7 @@ public abstract class OrganizationsApiService {
 
     public abstract Response organizationsOrganizationIdUserstoreConfigsGet(String organizationId);
 
-    public abstract Response organizationsOrganizationIdUserstoreConfigsPatch(String organizationId,
-            List<OperationDTO> operations);
+    public abstract Response organizationsOrganizationIdUserstoreConfigsPatch(String organizationId, List<OperationDTO> operations);
 
     public abstract Response organizationsPost(OrganizationAddDTO organization);
 }

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/OrganizationsApiService.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/OrganizationsApiService.java
@@ -40,13 +40,9 @@ public abstract class OrganizationsApiService {
 
     public abstract Response organizationsOrganizationIdPatch(String organizationId, List<OperationDTO> operations);
 
-    public abstract Response organizationsOrganizationIdRolesPatch(String organizationId,
-            List<OperationDTO> operations);
+    public abstract Response organizationsOrganizationIdRolesPost(String organizationId, UserRoleMappingDTO userRoles);
 
-    public abstract Response organizationsOrganizationIdRolesPost(String organizationId,
-            List<UserRoleMappingDTO> userRoles);
-
-    public abstract Response organizationsOrganizationIdRolesRoleIdUsersGet(String organizationId, String roleId);
+    public abstract Response organizationsOrganizationIdRolesRoleIdUsersGet(String organizationId, String roleId, Integer offset, Integer limit, String attributes, Boolean includeSubOrgs);
 
     public abstract Response organizationsOrganizationIdRolesRoleIdUsersUserIdDelete(String organizationId,
             String roleId, String userId);

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/dto/UserDTO.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/dto/UserDTO.java
@@ -16,6 +16,10 @@
 
 package org.wso2.carbon.identity.organization.mgt.endpoint.dto;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.organization.mgt.endpoint.dto.UserEmailsDTO;
+import org.wso2.carbon.identity.organization.mgt.endpoint.dto.UserNameDTO;
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
@@ -27,23 +31,18 @@ import javax.validation.constraints.Pattern;
 public class UserDTO {
 
     @Valid 
-    @NotNull(message = "Property userId cannot be null.") 
-    private String userId = null;
-
-    @Valid 
     @NotNull(message = "Property username cannot be null.") 
     private String username = null;
 
-    /**
-    **/
-    @ApiModelProperty(required = true, value = "")
-    @JsonProperty("userId")
-    public String getUserId() {
-        return userId;
-    }
-    public void setUserId(String userId) {
-        this.userId = userId;
-    }
+    @Valid 
+    @NotNull(message = "Property id cannot be null.") 
+    private String id = null;
+
+    @Valid 
+    private UserNameDTO name = null;
+
+    @Valid 
+    private List<UserEmailsDTO> emails = new ArrayList<UserEmailsDTO>();
 
     /**
     **/
@@ -56,14 +55,49 @@ public class UserDTO {
         this.username = username;
     }
 
+    /**
+    **/
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("name")
+    public UserNameDTO getName() {
+        return name;
+    }
+    public void setName(UserNameDTO name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("emails")
+    public List<UserEmailsDTO> getEmails() {
+        return emails;
+    }
+    public void setEmails(List<UserEmailsDTO> emails) {
+        this.emails = emails;
+    }
+
     @Override
     public String toString() {
 
         StringBuilder sb = new StringBuilder();
         sb.append("class UserDTO {\n");
         
-        sb.append("    userId: ").append(userId).append("\n");
         sb.append("    username: ").append(username).append("\n");
+        sb.append("    id: ").append(id).append("\n");
+        sb.append("    name: ").append(name).append("\n");
+        sb.append("    emails: ").append(emails).append("\n");
         
         sb.append("}\n");
         return sb.toString();

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/dto/UserEmailsDTO.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/dto/UserEmailsDTO.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.organization.mgt.endpoint.dto;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+@ApiModel(description = "")
+public class UserEmailsDTO {
+
+    @Valid 
+    private String type = null;
+
+    @Valid 
+    private String value = null;
+
+    @Valid 
+    private Boolean primary = null;
+
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("value")
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("primary")
+    public Boolean getPrimary() {
+        return primary;
+    }
+    public void setPrimary(Boolean primary) {
+        this.primary = primary;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserEmailsDTO {\n");
+        
+        sb.append("    type: ").append(type).append("\n");
+        sb.append("    value: ").append(value).append("\n");
+        sb.append("    primary: ").append(primary).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
+}

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/dto/UserNameDTO.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/dto/UserNameDTO.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.organization.mgt.endpoint.dto;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+@ApiModel(description = "")
+public class UserNameDTO {
+
+    @Valid 
+    private String givenName = null;
+
+    @Valid 
+    private String familyName = null;
+
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("givenName")
+    public String getGivenName() {
+        return givenName;
+    }
+    public void setGivenName(String givenName) {
+        this.givenName = givenName;
+    }
+
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("familyName")
+    public String getFamilyName() {
+        return familyName;
+    }
+    public void setFamilyName(String familyName) {
+        this.familyName = familyName;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserNameDTO {\n");
+        
+        sb.append("    givenName: ").append(givenName).append("\n");
+        sb.append("    familyName: ").append(familyName).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
+}

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/dto/UserRoleMappingUsersDTO.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/gen/java/org/wso2/carbon/identity/organization/mgt/endpoint/dto/UserRoleMappingUsersDTO.java
@@ -16,9 +16,6 @@
 
 package org.wso2.carbon.identity.organization.mgt.endpoint.dto;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.wso2.carbon.identity.organization.mgt.endpoint.dto.UserRoleMappingUsersDTO;
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
@@ -27,45 +24,45 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 @ApiModel(description = "")
-public class UserRoleMappingDTO {
+public class UserRoleMappingUsersDTO {
 
     @Valid 
-    @NotNull(message = "Property roleId cannot be null.") 
-    private String roleId = null;
+    private Boolean includeSubOrgs = null;
 
     @Valid 
-    private List<UserRoleMappingUsersDTO> users = new ArrayList<UserRoleMappingUsersDTO>();
-
-    /**
-    **/
-    @ApiModelProperty(required = true, value = "")
-    @JsonProperty("roleId")
-    public String getRoleId() {
-        return roleId;
-    }
-    public void setRoleId(String roleId) {
-        this.roleId = roleId;
-    }
+    @NotNull(message = "Property userId cannot be null.") 
+    private String userId = null;
 
     /**
     **/
     @ApiModelProperty(value = "")
-    @JsonProperty("users")
-    public List<UserRoleMappingUsersDTO> getUsers() {
-        return users;
+    @JsonProperty("includeSubOrgs")
+    public Boolean getIncludeSubOrgs() {
+        return includeSubOrgs;
     }
-    public void setUsers(List<UserRoleMappingUsersDTO> users) {
-        this.users = users;
+    public void setIncludeSubOrgs(Boolean includeSubOrgs) {
+        this.includeSubOrgs = includeSubOrgs;
+    }
+
+    /**
+    **/
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("userId")
+    public String getUserId() {
+        return userId;
+    }
+    public void setUserId(String userId) {
+        this.userId = userId;
     }
 
     @Override
     public String toString() {
 
         StringBuilder sb = new StringBuilder();
-        sb.append("class UserRoleMappingDTO {\n");
+        sb.append("class UserRoleMappingUsersDTO {\n");
         
-        sb.append("    roleId: ").append(roleId).append("\n");
-        sb.append("    users: ").append(users).append("\n");
+        sb.append("    includeSubOrgs: ").append(includeSubOrgs).append("\n");
+        sb.append("    userId: ").append(userId).append("\n");
         
         sb.append("}\n");
         return sb.toString();

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/impl/OrganizationsApiServiceImpl.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/impl/OrganizationsApiServiceImpl.java
@@ -250,7 +250,8 @@ public class OrganizationsApiServiceImpl extends OrganizationsApiService {
             String userId,  Boolean includeSubOrgs) {
 
         try {
-            getOrganizationUserRoleManager().deleteOrganizationsUserRoleMapping(organizationId, userId, roleId, includeSubOrgs);
+            boolean includeSubOrgsReq = includeSubOrgs != null ? includeSubOrgs.booleanValue() : false;
+            getOrganizationUserRoleManager().deleteOrganizationsUserRoleMapping(organizationId, userId, roleId, includeSubOrgsReq);
             return Response.noContent().build();
         } catch (OrganizationUserRoleMgtClientException e) {
             return OrganizationUserRoleMgtEndpointUtil.handleBadRequestResponse(e, log);

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/impl/OrganizationsApiServiceImpl.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/impl/OrganizationsApiServiceImpl.java
@@ -65,7 +65,6 @@ import static org.wso2.carbon.identity.organization.mgt.endpoint.util.Organizati
 import static org.wso2.carbon.identity.organization.mgt.endpoint.util.OrganizationMgtEndpointUtil.handleBadRequestResponse;
 import static org.wso2.carbon.identity.organization.mgt.endpoint.util.OrganizationMgtEndpointUtil.handleServerErrorResponse;
 import static org.wso2.carbon.identity.organization.mgt.endpoint.util.OrganizationMgtEndpointUtil.handleUnexpectedServerError;
-import static org.wso2.carbon.identity.organization.mgt.endpoint.util.OrganizationUserRoleMgtEndpointUtil.buildResponse;
 import static org.wso2.carbon.identity.organization.user.role.mgt.core.constant.OrganizationUserRoleMgtConstants.ErrorMessages.ERROR_CODE_INVALID_USER_GET_REQUEST_FOR_ORG_ROLE;
 
 /**
@@ -220,7 +219,7 @@ public class OrganizationsApiServiceImpl extends OrganizationsApiService {
 
     @Override
     public Response organizationsOrganizationIdRolesRoleIdUsersGet(String organizationId, String roleId, Integer offset,
-                                                                   Integer limit, String attributes, Boolean includeSubOrgs) {
+                                                                   Integer limit, String attributes) {
 
         try {
             if ((limit != null && limit < 1) || (offset != null && offset < 0)) {
@@ -232,16 +231,12 @@ public class OrganizationsApiServiceImpl extends OrganizationsApiService {
             // If pagination parameters not defined in the request, set them to -1
             limit = (limit == null) ? Integer.valueOf(-1) : limit;
             offset = (offset == null) ? Integer.valueOf(-1) : offset;
-            includeSubOrgs = includeSubOrgs != null;
             List<String> requestedAttributes = attributes == null ? new ArrayList<>() :
                     Arrays.stream(attributes.split(",")).map(String::trim).collect(Collectors.toList());
-            List<SCIMResponse> users = getOrganizationUserRoleManager()
-                    .getUsersByOrganizationAndRole(organizationId, roleId, offset, limit, requestedAttributes, includeSubOrgs);
-//            List<Response> usersResponse = new ArrayList<>();
-//            for(SCIMResponse user: users) {
-//                usersResponse.add(buildResponse(user));
-//            }
-            return Response.ok().entity(users).build();
+            List<User> users = getOrganizationUserRoleManager()
+                    .getUsersByOrganizationAndRole(organizationId, roleId, offset, limit, requestedAttributes);
+            return Response.ok().entity(users.stream().map(
+                    User::getUserAttributes).collect(Collectors.toList())).build();
         } catch (OrganizationUserRoleMgtClientException e) {
             return OrganizationUserRoleMgtEndpointUtil.handleBadRequestResponse(e, log);
         } catch (OrganizationUserRoleMgtException e) {

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/impl/OrganizationsApiServiceImpl.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/impl/OrganizationsApiServiceImpl.java
@@ -38,7 +38,6 @@ import org.wso2.carbon.identity.organization.user.role.mgt.core.model.Role;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.User;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.UserRoleMapping;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.UserRoleMappingUser;
-import org.wso2.charon3.core.protocol.SCIMResponse;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -206,7 +205,7 @@ public class OrganizationsApiServiceImpl extends OrganizationsApiService {
             UserRoleMapping userRoleMapping1 = new UserRoleMapping(userRoleMapping.getRoleId(),
                     userRoleMapping.getUsers().stream().map(mapping ->
                     new UserRoleMappingUser(mapping.getUserId(), mapping.getIncludeSubOrgs())).collect(Collectors.toList()));
-            getOrganizationUserRoleManager().addOrganizationAndUserRoleMappings(organizationId, userRoleMapping1);
+            getOrganizationUserRoleManager().addOrganizationUserRoleMappings(organizationId, userRoleMapping1);
             return Response.created(getOrganizationRoleResourceURI(organizationId)).build();
         } catch (OrganizationUserRoleMgtClientException e) {
             return OrganizationUserRoleMgtEndpointUtil.handleBadRequestResponse(e, log);
@@ -248,10 +247,10 @@ public class OrganizationsApiServiceImpl extends OrganizationsApiService {
 
     @Override
     public Response organizationsOrganizationIdRolesRoleIdUsersUserIdDelete(String organizationId, String roleId,
-            String userId) {
+            String userId,  Boolean includeSubOrgs) {
 
         try {
-            getOrganizationUserRoleManager().deleteOrganizationAndUserRoleMapping(organizationId, userId, roleId);
+            getOrganizationUserRoleManager().deleteOrganizationsUserRoleMapping(organizationId, userId, roleId, includeSubOrgs);
             return Response.noContent().build();
         } catch (OrganizationUserRoleMgtClientException e) {
             return OrganizationUserRoleMgtEndpointUtil.handleBadRequestResponse(e, log);

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/impl/OrganizationsApiServiceImpl.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/impl/OrganizationsApiServiceImpl.java
@@ -204,7 +204,8 @@ public class OrganizationsApiServiceImpl extends OrganizationsApiService {
         try {
             UserRoleMapping userRoleMapping1 = new UserRoleMapping(userRoleMapping.getRoleId(),
                     userRoleMapping.getUsers().stream().map(mapping ->
-                    new UserRoleMappingUser(mapping.getUserId(), mapping.getIncludeSubOrgs())).collect(Collectors.toList()));
+                            new UserRoleMappingUser(mapping.getUserId(), mapping.getIncludeSubOrgs()))
+                            .collect(Collectors.toList()));
             getOrganizationUserRoleManager().addOrganizationUserRoleMappings(organizationId, userRoleMapping1);
             return Response.created(getOrganizationRoleResourceURI(organizationId)).build();
         } catch (OrganizationUserRoleMgtClientException e) {
@@ -251,7 +252,8 @@ public class OrganizationsApiServiceImpl extends OrganizationsApiService {
 
         try {
             boolean includeSubOrgsReq = includeSubOrgs != null ? includeSubOrgs.booleanValue() : false;
-            getOrganizationUserRoleManager().deleteOrganizationsUserRoleMapping(organizationId, userId, roleId, includeSubOrgsReq);
+            getOrganizationUserRoleManager()
+                    .deleteOrganizationsUserRoleMapping(organizationId, userId, roleId, includeSubOrgsReq);
             return Response.noContent().build();
         } catch (OrganizationUserRoleMgtClientException e) {
             return OrganizationUserRoleMgtEndpointUtil.handleBadRequestResponse(e, log);

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/impl/OrganizationsApiServiceImpl.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/impl/OrganizationsApiServiceImpl.java
@@ -37,6 +37,8 @@ import org.wso2.carbon.identity.organization.user.role.mgt.core.exception.Organi
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.Role;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.User;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.UserRoleMapping;
+import org.wso2.carbon.identity.organization.user.role.mgt.core.model.UserRoleMappingUser;
+import org.wso2.charon3.core.protocol.SCIMResponse;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -63,7 +65,8 @@ import static org.wso2.carbon.identity.organization.mgt.endpoint.util.Organizati
 import static org.wso2.carbon.identity.organization.mgt.endpoint.util.OrganizationMgtEndpointUtil.handleBadRequestResponse;
 import static org.wso2.carbon.identity.organization.mgt.endpoint.util.OrganizationMgtEndpointUtil.handleServerErrorResponse;
 import static org.wso2.carbon.identity.organization.mgt.endpoint.util.OrganizationMgtEndpointUtil.handleUnexpectedServerError;
-import static org.wso2.carbon.identity.organization.mgt.endpoint.util.OrganizationUserRoleMgtEndpointUtil.getUserDTOsFromUsers;
+import static org.wso2.carbon.identity.organization.mgt.endpoint.util.OrganizationUserRoleMgtEndpointUtil.buildResponse;
+import static org.wso2.carbon.identity.organization.user.role.mgt.core.constant.OrganizationUserRoleMgtConstants.ErrorMessages.ERROR_CODE_INVALID_USER_GET_REQUEST_FOR_ORG_ROLE;
 
 /**
  * Organizations Api Service Impl.
@@ -198,29 +201,13 @@ public class OrganizationsApiServiceImpl extends OrganizationsApiService {
     }
 
     @Override
-    public Response organizationsOrganizationIdRolesPatch(String organizationId, List<OperationDTO> operations) {
+    public Response organizationsOrganizationIdRolesPost(String organizationId, UserRoleMappingDTO userRoleMapping) {
 
         try {
-            getOrganizationUserRoleManager().patchOrganizationAndUserRoleMapping(organizationId, operations.stream()
-                    .map(op -> new org.wso2.carbon.identity.organization.user.role.mgt.core.model.Operation(op.getOp(),
-                            op.getPath(), op.getValue())).collect(Collectors.toList()));
-            return Response.noContent().build();
-        } catch (OrganizationUserRoleMgtClientException e) {
-            return OrganizationUserRoleMgtEndpointUtil.handleBadRequestResponse(e, log);
-        } catch (OrganizationUserRoleMgtException e) {
-            return OrganizationUserRoleMgtEndpointUtil.handleServerErrorResponse(e, log);
-        } catch (Throwable throwable) {
-            return OrganizationUserRoleMgtEndpointUtil.handleUnexpectedServerError(throwable, log);
-        }
-    }
-
-    @Override
-    public Response organizationsOrganizationIdRolesPost(String organizationId, List<UserRoleMappingDTO> userRoles) {
-
-        try {
-            getOrganizationUserRoleManager().addOrganizationAndUserRoleMappings(organizationId,
-                    userRoles.stream().map(mapping -> new UserRoleMapping(mapping.getRoleId(), mapping.getUsers()))
-                            .collect(Collectors.toList()));
+            UserRoleMapping userRoleMapping1 = new UserRoleMapping(userRoleMapping.getRoleId(),
+                    userRoleMapping.getUsers().stream().map(mapping ->
+                    new UserRoleMappingUser(mapping.getUserId(), mapping.getIncludeSubOrgs())).collect(Collectors.toList()));
+            getOrganizationUserRoleManager().addOrganizationAndUserRoleMappings(organizationId, userRoleMapping1);
             return Response.created(getOrganizationRoleResourceURI(organizationId)).build();
         } catch (OrganizationUserRoleMgtClientException e) {
             return OrganizationUserRoleMgtEndpointUtil.handleBadRequestResponse(e, log);
@@ -232,11 +219,29 @@ public class OrganizationsApiServiceImpl extends OrganizationsApiService {
     }
 
     @Override
-    public Response organizationsOrganizationIdRolesRoleIdUsersGet(String organizationId, String roleId) {
+    public Response organizationsOrganizationIdRolesRoleIdUsersGet(String organizationId, String roleId, Integer offset,
+                                                                   Integer limit, String attributes, Boolean includeSubOrgs) {
 
         try {
-            List<User> users = getOrganizationUserRoleManager().getUsersByOrganizationAndRole(organizationId, roleId);
-            return Response.ok().entity(getUserDTOsFromUsers(users)).build();
+            if ((limit != null && limit < 1) || (offset != null && offset < 0)) {
+                throw org.wso2.carbon.identity.organization.user.role.mgt.core.util.Utils
+                        .handleClientException(ERROR_CODE_INVALID_USER_GET_REQUEST_FOR_ORG_ROLE,
+                                "Invalid pagination arguments. 'limit' should be greater than 0 and 'offset' should be "
+                                        + "greater than -1");
+            }
+            // If pagination parameters not defined in the request, set them to -1
+            limit = (limit == null) ? Integer.valueOf(-1) : limit;
+            offset = (offset == null) ? Integer.valueOf(-1) : offset;
+            includeSubOrgs = includeSubOrgs != null;
+            List<String> requestedAttributes = attributes == null ? new ArrayList<>() :
+                    Arrays.stream(attributes.split(",")).map(String::trim).collect(Collectors.toList());
+            List<SCIMResponse> users = getOrganizationUserRoleManager()
+                    .getUsersByOrganizationAndRole(organizationId, roleId, offset, limit, requestedAttributes, includeSubOrgs);
+//            List<Response> usersResponse = new ArrayList<>();
+//            for(SCIMResponse user: users) {
+//                usersResponse.add(buildResponse(user));
+//            }
+            return Response.ok().entity(users).build();
         } catch (OrganizationUserRoleMgtClientException e) {
             return OrganizationUserRoleMgtEndpointUtil.handleBadRequestResponse(e, log);
         } catch (OrganizationUserRoleMgtException e) {

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/util/OrganizationUserRoleMgtEndpointUtil.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/util/OrganizationUserRoleMgtEndpointUtil.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.identity.organization.mgt.endpoint.util;
 
 import org.apache.commons.logging.Log;
 import org.wso2.carbon.identity.organization.mgt.endpoint.dto.ErrorDTO;
-import org.wso2.carbon.identity.organization.mgt.endpoint.dto.UserDTO;
 import org.wso2.carbon.identity.organization.mgt.endpoint.exceptions.BadRequestException;
 import org.wso2.carbon.identity.organization.mgt.endpoint.exceptions.ConflictRequestException;
 import org.wso2.carbon.identity.organization.mgt.endpoint.exceptions.ForbiddenException;
@@ -28,10 +27,6 @@ import org.wso2.carbon.identity.organization.mgt.endpoint.exceptions.InternalSer
 import org.wso2.carbon.identity.organization.mgt.endpoint.exceptions.NotFoundException;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.exception.OrganizationUserRoleMgtClientException;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.exception.OrganizationUserRoleMgtException;
-import org.wso2.carbon.identity.organization.user.role.mgt.core.model.User;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.ws.rs.core.Response;
 

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/util/OrganizationUserRoleMgtEndpointUtil.java
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/java/org/wso2/carbon/identity/organization/mgt/endpoint/util/OrganizationUserRoleMgtEndpointUtil.java
@@ -144,16 +144,4 @@ public class OrganizationUserRoleMgtEndpointUtil {
 
         log.error(throwable.getMessage(), throwable);
     }
-
-    public static List<UserDTO> getUserDTOsFromUsers(List<User> users) {
-
-        List<UserDTO> userDTOs = new ArrayList<>();
-        for (User user : users) {
-            UserDTO userDTO = new UserDTO();
-            userDTO.setUserId(user.getUserId());
-            userDTO.setUsername(user.getUserName());
-            userDTOs.add(userDTO);
-        }
-        return userDTOs;
-    }
 }

--- a/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
+++ b/org.wso2.carbon.identity.organization.mgt.endpoint/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
@@ -782,6 +782,10 @@ paths:
           description: 'ID of the user.'
           required: true
           type: string
+        - name: includeSubOrgs
+          in: query
+          type: boolean
+          description: Filter the role mappings to delete. Check whether sub organization's role mappings will be deleted or not.
       responses:
         '204':
           description: No Content

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/pom.xml
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/pom.xml
@@ -96,6 +96,17 @@
             <artifactId>annotations</artifactId>
             <version>3.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.mgt.core</artifactId>
+            <version>5.17.5</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManager.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManager.java
@@ -18,26 +18,31 @@
 
 package org.wso2.carbon.identity.organization.user.role.mgt.core;
 
+import org.json.JSONObject;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.exception.OrganizationUserRoleMgtException;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.Operation;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.Role;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.User;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.UserRoleMapping;
+import org.wso2.charon3.core.protocol.SCIMResponse;
 
 import java.util.List;
+
+import javax.ws.rs.core.Response;
 
 /**
  * Organization and user role manager service interface.
  */
 public interface OrganizationUserRoleManager {
 
-    void addOrganizationAndUserRoleMappings(String organizationId, List<UserRoleMapping> userRoleMappings)
+    void addOrganizationAndUserRoleMappings(String organizationId, UserRoleMapping userRoleMappings)
             throws OrganizationUserRoleMgtException;
 
     void patchOrganizationAndUserRoleMapping(String organizationId, List<Operation> operations)
             throws OrganizationUserRoleMgtException;
 
-    List<User> getUsersByOrganizationAndRole(String organizationID, String roleId)
+    List<User> getUsersByOrganizationAndRole(String organizationID, String roleId, int offset, int limit,
+                                             List<String> requestedAttributes)
             throws OrganizationUserRoleMgtException;
 
     void deleteOrganizationAndUserRoleMapping(String organizationId, String userId, String roleId)

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManager.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManager.java
@@ -36,22 +36,19 @@ import javax.ws.rs.core.Response;
  */
 public interface OrganizationUserRoleManager {
 
-    void addOrganizationAndUserRoleMappings(String organizationId, UserRoleMapping userRoleMappings)
+    void addOrganizationUserRoleMappings(String organizationId, UserRoleMapping userRoleMappings)
             throws OrganizationUserRoleMgtException, OrganizationManagementException;
-
-    void patchOrganizationAndUserRoleMapping(String organizationId, List<Operation> operations)
-            throws OrganizationUserRoleMgtException;
 
     List<User> getUsersByOrganizationAndRole(String organizationID, String roleId, int offset, int limit,
                                              List<String> requestedAttributes)
             throws OrganizationUserRoleMgtException;
 
-    void deleteOrganizationAndUserRoleMapping(String organizationId, String userId, String roleId)
-            throws OrganizationUserRoleMgtException;
+    void deleteOrganizationsUserRoleMapping(String organizationId, String userId, String roleId, boolean includeSubOrgs)
+            throws OrganizationUserRoleMgtException, OrganizationManagementException;
 
     List<Role> getRolesByOrganizationAndUser(String organizationId, String userId)
             throws OrganizationUserRoleMgtException;
 
-    boolean isOrganizationAndUserRoleMappingExists(String organizationId, String userId, String roleId)
+    boolean isOrganizationUserRoleMappingExists(String organizationId, String userId, String roleId)
             throws OrganizationUserRoleMgtException;
 }

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManager.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManager.java
@@ -18,18 +18,14 @@
 
 package org.wso2.carbon.identity.organization.user.role.mgt.core;
 
-import org.json.JSONObject;
 import org.wso2.carbon.identity.organization.mgt.core.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.exception.OrganizationUserRoleMgtException;
-import org.wso2.carbon.identity.organization.user.role.mgt.core.model.Operation;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.Role;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.User;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.UserRoleMapping;
-import org.wso2.charon3.core.protocol.SCIMResponse;
 
 import java.util.List;
 
-import javax.ws.rs.core.Response;
 
 /**
  * Organization and user role manager service interface.

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManager.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManager.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.organization.user.role.mgt.core;
 
 import org.json.JSONObject;
+import org.wso2.carbon.identity.organization.mgt.core.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.exception.OrganizationUserRoleMgtException;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.Operation;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.Role;
@@ -36,7 +37,7 @@ import javax.ws.rs.core.Response;
 public interface OrganizationUserRoleManager {
 
     void addOrganizationAndUserRoleMappings(String organizationId, UserRoleMapping userRoleMappings)
-            throws OrganizationUserRoleMgtException;
+            throws OrganizationUserRoleMgtException, OrganizationManagementException;
 
     void patchOrganizationAndUserRoleMapping(String organizationId, List<Operation> operations)
             throws OrganizationUserRoleMgtException;

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManagerImpl.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManagerImpl.java
@@ -182,7 +182,6 @@ public class OrganizationUserRoleManagerImpl implements OrganizationUserRoleMana
             organizationUserRoleMapping.setRoleId(roleId);
             organizationUserRoleMapping.setHybridRoleId(hybridRoleId);
             organizationUserRoleMapping.setUserId(user.getUserId());
-            organizationUserRoleMapping.setCascadedRole(user.isCascadedRole());
             organizationUserRoleMappings.add(organizationUserRoleMapping);
         }
         return organizationUserRoleMappings;

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManagerImpl.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManagerImpl.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.organization.user.role.mgt.core.model.Organizati
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.Role;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.User;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.UserRoleMapping;
+import org.wso2.carbon.identity.organization.user.role.mgt.core.model.UserRoleMappingUser;
 import org.wso2.carbon.identity.scim2.common.DAO.GroupDAO;
 import org.wso2.carbon.identity.scim2.common.exceptions.IdentitySCIMException;
 
@@ -45,48 +46,44 @@ import static org.wso2.carbon.identity.organization.user.role.mgt.core.util.Util
 public class OrganizationUserRoleManagerImpl implements OrganizationUserRoleManager {
 
     @Override
-    public void addOrganizationAndUserRoleMappings(String organizationId, List<UserRoleMapping> userRoleMappings)
+    public void addOrganizationAndUserRoleMappings(String organizationId, UserRoleMapping userRoleMapping)
             throws OrganizationUserRoleMgtException {
 
 //        validateAddRoleMappingRequest(organizationUserRoleMappings);
         GroupDAO groupDAO = new GroupDAO();
         OrganizationUserRoleMgtDAO organizationUserRoleMgtDAO = new OrganizationUserRoleMgtDAOImpl();
 
-        for (UserRoleMapping userRoleMapping : userRoleMappings) {
-            try {
-                String groupName = groupDAO.getGroupNameById(getTenantId(), userRoleMapping.getRoleId());
-                if (groupName == null) {
-                    throw handleClientException(ERROR_CODE_INVALID_ROLE_ERROR, userRoleMapping.getRoleId());
-                }
-                String[] groupNameParts = groupName.split("/");
-                if (groupNameParts.length != 2) {
-                    throw handleServerException(ERROR_CODE_INVALID_ROLE_ERROR, groupName);
-                }
-                String domain = groupNameParts[0];
-                if (!"INTERNAL".equalsIgnoreCase(domain)) {
-                    throw handleClientException(ERROR_CODE_ADD_NONE_INTERNAL_ERROR, groupName);
-                }
-                String roleName = groupNameParts[1];
-                Integer hybridRoleId = organizationUserRoleMgtDAO.getRoleIdBySCIMGroupName(roleName, getTenantId());
-                userRoleMapping.setHybridRoleId(hybridRoleId);
-            } catch (IdentitySCIMException e) {
-                throw new OrganizationUserRoleMgtServerException(e);
+        try {
+            String groupName = groupDAO.getGroupNameById(getTenantId(), userRoleMapping.getRoleId());
+            if (groupName == null) {
+                throw handleClientException(ERROR_CODE_INVALID_ROLE_ERROR, userRoleMapping.getRoleId());
             }
+            String[] groupNameParts = groupName.split("/");
+            if (groupNameParts.length != 2) {
+                throw handleServerException(ERROR_CODE_INVALID_ROLE_ERROR, groupName);
+            }
+            String domain = groupNameParts[0];
+            if (!"INTERNAL".equalsIgnoreCase(domain)) {
+                throw handleClientException(ERROR_CODE_ADD_NONE_INTERNAL_ERROR, groupName);
+            }
+            String roleName = groupNameParts[1];
+            Integer hybridRoleId = organizationUserRoleMgtDAO.getRoleIdBySCIMGroupName(roleName, getTenantId());
+            userRoleMapping.setHybridRoleId(hybridRoleId);
+        } catch (IdentitySCIMException e) {
+            throw new OrganizationUserRoleMgtServerException(e);
         }
 
         //@TODO check for mapping existance
         List<OrganizationUserRoleMapping> organizationUserRoleMappings = new ArrayList<>();
-        for (UserRoleMapping userRoleMapping : userRoleMappings) {
-            for (String userID : userRoleMapping.getUserIds()) {
-                OrganizationUserRoleMapping organizationUserRoleMapping = new OrganizationUserRoleMapping();
-                organizationUserRoleMapping.setOrganizationId(organizationId);
-                organizationUserRoleMapping.setRoleId(userRoleMapping.getRoleId());
-                organizationUserRoleMapping.setHybridRoleId(userRoleMapping.getHybridRoleId());
-                organizationUserRoleMapping.setUserId(userID);
-                organizationUserRoleMappings.add(organizationUserRoleMapping);
-            }
+        for (UserRoleMappingUser user : userRoleMapping.getUsers()) {
+            OrganizationUserRoleMapping organizationUserRoleMapping = new OrganizationUserRoleMapping();
+            organizationUserRoleMapping.setOrganizationId(organizationId);
+            organizationUserRoleMapping.setRoleId(userRoleMapping.getRoleId());
+            organizationUserRoleMapping.setHybridRoleId(userRoleMapping.getHybridRoleId());
+            organizationUserRoleMapping.setUserId(user.getUserId());
+            organizationUserRoleMapping.setCascadedRole(user.isCascadedRole());
+            organizationUserRoleMappings.add(organizationUserRoleMapping);
         }
-
         organizationUserRoleMgtDAO.addOrganizationAndUserRoleMappings(organizationUserRoleMappings, getTenantId());
     }
 
@@ -97,11 +94,14 @@ public class OrganizationUserRoleManagerImpl implements OrganizationUserRoleMana
     }
 
     @Override
-    public List<User> getUsersByOrganizationAndRole(String organizationID, String roleId)
+    public List<User> getUsersByOrganizationAndRole(String organizationID, String roleId, int offset, int limit,
+                                                    List<String> requestedAttributes)
             throws OrganizationUserRoleMgtException {
 
         OrganizationUserRoleMgtDAO organizationUserRoleMgtDAO = new OrganizationUserRoleMgtDAOImpl();
-        return organizationUserRoleMgtDAO.getUserIdsByOrganizationAndRole(organizationID, roleId, getTenantId());
+        return organizationUserRoleMgtDAO
+                .getUserIdsByOrganizationAndRole(organizationID, roleId, offset, limit, requestedAttributes,
+                        getTenantId());
     }
 
     @Override

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManagerImpl.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManagerImpl.java
@@ -28,7 +28,6 @@ import org.wso2.carbon.identity.organization.user.role.mgt.core.dao.Organization
 import org.wso2.carbon.identity.organization.user.role.mgt.core.dao.OrganizationUserRoleMgtDAOImpl;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.exception.OrganizationUserRoleMgtException;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.exception.OrganizationUserRoleMgtServerException;
-import org.wso2.carbon.identity.organization.user.role.mgt.core.model.Operation;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.OrganizationUserRoleMapping;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.Role;
 import org.wso2.carbon.identity.organization.user.role.mgt.core.model.User;
@@ -145,7 +144,10 @@ public class OrganizationUserRoleManagerImpl implements OrganizationUserRoleMana
         List<String> organizationListToBeDeleted = new ArrayList<>();
         organizationListToBeDeleted.add(organizationId);
 
-        // Traverse the sub organizations and added as the organizations to be checked for deleting the mentioned role mapping.
+        /*
+        Traverse the sub organizations and added as the organizations to be checked for deleting the
+        mentioned role mapping.
+         */
         if (includeSubOrgs) {
             Queue<String> organizationsList = new LinkedList<>();
             // Add starting organization.

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/OrganizationUserRoleMgtConstants.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/OrganizationUserRoleMgtConstants.java
@@ -36,7 +36,7 @@ public class OrganizationUserRoleMgtConstants {
 
         // Server errors (ORGPERMMGT_00020-ORGPERMMGT_00040)
         ERROR_CODE_ORGANIZATION_USER_ROLE_MAPPINGS_ADD_ERROR("ORGPERMMGT_00020",
-                "Error while creating the role mapping for organization : %s"),
+                "Error while creating the role mappings"),
         ERROR_CODE_ORGANIZATION_USER_ROLE_MAPPINGS_DELETE_ERROR("ORGPERMMGT_00021",
                 "Error while deleting the role : %s, for user : %s for organization : %s"),
         ERROR_CODE_ORGANIZATION_USER_ROLE_MAPPINGS_RETRIEVING_ERROR("ORGPERMMGT_00022",

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/OrganizationUserRoleMgtConstants.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/OrganizationUserRoleMgtConstants.java
@@ -32,6 +32,7 @@ public class OrganizationUserRoleMgtConstants {
         ERROR_CODE_ADD_NONE_INTERNAL_ERROR("ORGPERMMGT_00001",
                 "Only internal roles are allowed. Role : %s is not an internal role."),
         ERROR_CODE_INVALID_ROLE_ID_ERROR("ORGPERMMGT_00002", "Invalid role id: %s"),
+        ERROR_CODE_INVALID_USER_GET_REQUEST_FOR_ORG_ROLE("ORGPERMMGT_00003", "Invalid users search/get request for an organization's role: %s"),
 
         // Server errors (ORGPERMMGT_00020-ORGPERMMGT_00040)
         ERROR_CODE_ORGANIZATION_USER_ROLE_MAPPINGS_ADD_ERROR("ORGPERMMGT_00020",

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/OrganizationUserRoleMgtConstants.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/OrganizationUserRoleMgtConstants.java
@@ -32,7 +32,8 @@ public class OrganizationUserRoleMgtConstants {
         ERROR_CODE_ADD_NONE_INTERNAL_ERROR("ORGPERMMGT_00001",
                 "Only internal roles are allowed. Role : %s is not an internal role."),
         ERROR_CODE_INVALID_ROLE_ID_ERROR("ORGPERMMGT_00002", "Invalid role id: %s"),
-        ERROR_CODE_INVALID_USER_GET_REQUEST_FOR_ORG_ROLE("ORGPERMMGT_00003", "Invalid users search/get request for an organization's role: %s"),
+        ERROR_CODE_INVALID_USER_GET_REQUEST_FOR_ORG_ROLE("ORGPERMMGT_00003",
+                "Invalid users search/get request for an organization's role: %s"),
 
         // Server errors (ORGPERMMGT_00020-ORGPERMMGT_00040)
         ERROR_CODE_ORGANIZATION_USER_ROLE_MAPPINGS_ADD_ERROR("ORGPERMMGT_00020",

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/OrganizationUserRoleMgtConstants.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/OrganizationUserRoleMgtConstants.java
@@ -38,7 +38,7 @@ public class OrganizationUserRoleMgtConstants {
         ERROR_CODE_ORGANIZATION_USER_ROLE_MAPPINGS_ADD_ERROR("ORGPERMMGT_00020",
                 "Error while creating the role mappings"),
         ERROR_CODE_ORGANIZATION_USER_ROLE_MAPPINGS_DELETE_ERROR("ORGPERMMGT_00021",
-                "Error while deleting the role : %s, for user : %s for organization : %s"),
+                "Error while deleting the role : %s, for user : %s for organizations"),
         ERROR_CODE_ORGANIZATION_USER_ROLE_MAPPINGS_RETRIEVING_ERROR("ORGPERMMGT_00022",
                 "Error while retrieving the role : %s, for user : %s for organization : %s"),
         ERROR_CODE_HYBRID_ROLE_ID_RETRIEVING_ERROR("ORGPERMMGT_00023",

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/SQLConstants.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/SQLConstants.java
@@ -31,8 +31,8 @@ public class SQLConstants {
     public static final String VIEW_ROLE_NAME_COLUMN = "UM_ROLE_NAME";
 
     public static final String INSERT_INTO_ORGANIZATION_USER_ROLE_MAPPING =
-            "INTO UM_USER_ROLE_ORG (UM_ID, UM_USER_ID, UM_ROLE_ID, UM_HYBRID_ROLE_ID, UM_TENANT_ID, ORG_ID, INHERITANCE) " +
-                    "VALUES (?, ?, ?, ?, ?, ?, ?) ";
+            "INTO UM_USER_ROLE_ORG (UM_ID, UM_USER_ID, UM_ROLE_ID, UM_HYBRID_ROLE_ID, UM_TENANT_ID, ORG_ID) " +
+                    "VALUES (?, ?, ?, ?, ?, ?) ";
     public static final String SELECT_DUMMY_RECORD = "SELECT 1 FROM DUAL";
     public static final String INSERT_ORGANIZATION_USER_ROLE_MAPPING =
             "INSERT INTO\n" +
@@ -86,4 +86,11 @@ public class SQLConstants {
                     "%n   %s ROWS" +
                     "%n FETCH NEXT" +
                     "%n   %s ROWS ONLY";
+    public static final String UPSERT_UM_USER_ROLE_ORG_BASE = "MERGE INTO UM_USER_ROLE_ORG T USING ";
+    public static final String UNION_ALL = " UNION ALL ";
+    public static final String UM_USER_ROLE_ORG_DATA = "SELECT  ? UM_ID, ? UM_USER_ID, ? UM_ROLE_ID, ? UM_HYBRID_ROLE_ID, ? UM_TENANT_ID, ? ORG_ID from dual";
+    public static final String UPSERT_UM_USER_ROLE_ORG_END = " S\n" +
+            "ON (T.UM_ID = S.UM_ID AND T.UM_HYBRID_ROLE_ID = S.UM_HYBRID_ROLE_ID AND T.UM_TENANT_ID = S.UM_TENANT_ID AND T.ORG_ID = S.ORG_ID)\n" +
+            "WHEN NOT MATCHED THEN INSERT (UM_ID, UM_USER_ID, UM_ROLE_ID, UM_HYBRID_ROLE_ID, UM_TENANT_ID, ORG_ID)\n" +
+            "VALUES (S.UM_ID, S.UM_USER_ID, S.UM_ROLE_ID, S.UM_HYBRID_ROLE_ID, S.UM_TENANT_ID, S.ORG_ID)";
 }

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/SQLConstants.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/SQLConstants.java
@@ -29,6 +29,9 @@ public class SQLConstants {
     public static final String VIEW_USER_ID_COLUMN = "UM_USER_ID";
     public static final String VIEW_ROLE_ID_COLUMN = "UM_ROLE_ID";
     public static final String VIEW_ROLE_NAME_COLUMN = "UM_ROLE_NAME";
+    public static final String AND = " AND ";
+    public static final String OR = " OR ";
+    public static final String ORG_ID_ADDING = "ORG_ID = ?";
 
     public static final String INSERT_INTO_ORGANIZATION_USER_ROLE_MAPPING =
             "INTO UM_USER_ROLE_ORG (UM_ID, UM_USER_ID, UM_ROLE_ID, UM_HYBRID_ROLE_ID, UM_TENANT_ID, ORG_ID) " +
@@ -40,12 +43,12 @@ public class SQLConstants {
                     "    (UM_ID, UM_USER_ID, UM_ROLE_ID, UM_TENANT_ID, ORG_ID)\n" +
                     "VALUES\n" +
                     "    (?, ?, ?, ?, ?)";
-    public static final String DELETE_ORGANIZATION_USER_ROLE_MAPPING =
+    public static final String DELETE_ORGANIZATION_USER_ROLE_MAPPING_WITHOUT_ORG =
             "DELETE\n" +
                     "FROM\n" +
                     "    UM_USER_ROLE_ORG\n" +
                     "WHERE\n" +
-                    "    UM_USER_ID = ? AND UM_ROLE_ID = ? AND UM_TENANT_ID = ? AND ORG_ID = ?";
+                    "    UM_USER_ID = ? AND UM_ROLE_ID = ? AND UM_TENANT_ID = ?";
     public static final String GET_ORGANIZATION_USER_ROLE_MAPPING =
             "SELECT\n" +
                     "    COUNT(1)\n" +

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/SQLConstants.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/SQLConstants.java
@@ -93,7 +93,7 @@ public class SQLConstants {
     public static final String UNION_ALL = " UNION ALL ";
     public static final String UM_USER_ROLE_ORG_DATA = "SELECT  ? UM_ID, ? UM_USER_ID, ? UM_ROLE_ID, ? UM_HYBRID_ROLE_ID, ? UM_TENANT_ID, ? ORG_ID from dual";
     public static final String UPSERT_UM_USER_ROLE_ORG_END = " S\n" +
-            "ON (T.UM_ID = S.UM_ID AND T.UM_HYBRID_ROLE_ID = S.UM_HYBRID_ROLE_ID AND T.UM_TENANT_ID = S.UM_TENANT_ID AND T.ORG_ID = S.ORG_ID)\n" +
+            "ON (T.UM_USER_ID = S.UM_USER_ID AND T.UM_HYBRID_ROLE_ID = S.UM_HYBRID_ROLE_ID AND T.UM_TENANT_ID = S.UM_TENANT_ID AND T.ORG_ID = S.ORG_ID)\n" +
             "WHEN NOT MATCHED THEN INSERT (UM_ID, UM_USER_ID, UM_ROLE_ID, UM_HYBRID_ROLE_ID, UM_TENANT_ID, ORG_ID)\n" +
             "VALUES (S.UM_ID, S.UM_USER_ID, S.UM_ROLE_ID, S.UM_HYBRID_ROLE_ID, S.UM_TENANT_ID, S.ORG_ID)";
 }

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/SQLConstants.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/SQLConstants.java
@@ -31,8 +31,8 @@ public class SQLConstants {
     public static final String VIEW_ROLE_NAME_COLUMN = "UM_ROLE_NAME";
 
     public static final String INSERT_INTO_ORGANIZATION_USER_ROLE_MAPPING =
-            "INTO UM_USER_ROLE_ORG (UM_ID, UM_USER_ID, UM_ROLE_ID, UM_HYBRID_ROLE_ID, UM_TENANT_ID, ORG_ID) " +
-                    "VALUES (?, ?, ?, ?, ?, ?) ";
+            "INTO UM_USER_ROLE_ORG (UM_ID, UM_USER_ID, UM_ROLE_ID, UM_HYBRID_ROLE_ID, UM_TENANT_ID, ORG_ID, INHERITANCE) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?) ";
     public static final String SELECT_DUMMY_RECORD = "SELECT 1 FROM DUAL";
     public static final String INSERT_ORGANIZATION_USER_ROLE_MAPPING =
             "INSERT INTO\n" +
@@ -81,4 +81,9 @@ public class SQLConstants {
                     "    ORG_AUTHZ_VIEW\n" +
                     "WHERE\n" +
                     "    ORG_ID = ? AND UM_USER_ID = ? AND UM_TENANT_ID = ?";
+    public static final String PAGINATION =
+            "%n OFFSET" +
+                    "%n   %s ROWS" +
+                    "%n FETCH NEXT" +
+                    "%n   %s ROWS ONLY";
 }

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/SQLConstants.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/SQLConstants.java
@@ -91,9 +91,11 @@ public class SQLConstants {
                     "%n   %s ROWS ONLY";
     public static final String UPSERT_UM_USER_ROLE_ORG_BASE = "MERGE INTO UM_USER_ROLE_ORG T USING ";
     public static final String UNION_ALL = " UNION ALL ";
-    public static final String UM_USER_ROLE_ORG_DATA = "SELECT  ? UM_ID, ? UM_USER_ID, ? UM_ROLE_ID, ? UM_HYBRID_ROLE_ID, ? UM_TENANT_ID, ? ORG_ID from dual";
-    public static final String UPSERT_UM_USER_ROLE_ORG_END = " S\n" +
-            "ON (T.UM_USER_ID = S.UM_USER_ID AND T.UM_HYBRID_ROLE_ID = S.UM_HYBRID_ROLE_ID AND T.UM_TENANT_ID = S.UM_TENANT_ID AND T.ORG_ID = S.ORG_ID)\n" +
+    public static final String UM_USER_ROLE_ORG_DATA = "SELECT ? UM_ID, ? UM_USER_ID, ? UM_ROLE_ID, " +
+            "? UM_HYBRID_ROLE_ID, ? UM_TENANT_ID, ? ORG_ID from dual";
+    public static final String UPSERT_UM_USER_ROLE_ORG_END = " S ON \n" +
+            "(T.UM_USER_ID = S.UM_USER_ID AND T.UM_HYBRID_ROLE_ID = S.UM_HYBRID_ROLE_ID AND " +
+            "T.UM_TENANT_ID = S.UM_TENANT_ID AND T.ORG_ID = S.ORG_ID)\n" +
             "WHEN NOT MATCHED THEN INSERT (UM_ID, UM_USER_ID, UM_ROLE_ID, UM_HYBRID_ROLE_ID, UM_TENANT_ID, ORG_ID)\n" +
             "VALUES (S.UM_ID, S.UM_USER_ID, S.UM_ROLE_ID, S.UM_HYBRID_ROLE_ID, S.UM_TENANT_ID, S.ORG_ID)";
 }

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/dao/OrganizationUserRoleMgtDAO.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/dao/OrganizationUserRoleMgtDAO.java
@@ -31,8 +31,7 @@ import java.util.List;
  */
 public interface OrganizationUserRoleMgtDAO {
 
-    void addOrganizationAndUserRoleMappings(List<OrganizationUserRoleMapping> organizationUserRoleMapping,
-                                            int tenantID)
+    void addOrganizationAndUserRoleMappings(List<OrganizationUserRoleMapping> organizationUserRoleMapping, int tenantID)
             throws OrganizationUserRoleMgtException;
 
     List<User> getUserIdsByOrganizationAndRole(String organizationID, String roleId, int offset, int limit,

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/dao/OrganizationUserRoleMgtDAO.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/dao/OrganizationUserRoleMgtDAO.java
@@ -31,20 +31,20 @@ import java.util.List;
  */
 public interface OrganizationUserRoleMgtDAO {
 
-    void addOrganizationAndUserRoleMappings(List<OrganizationUserRoleMapping> organizationUserRoleMapping, int tenantID)
+    void addOrganizationUserRoleMappings(List<OrganizationUserRoleMapping> organizationUserRoleMappings, int tenantID)
             throws OrganizationUserRoleMgtException;
 
     List<User> getUserIdsByOrganizationAndRole(String organizationID, String roleId, int offset, int limit,
                                                List<String> requestedAttributes, int tenantID)
             throws OrganizationUserRoleMgtServerException;
 
-    void deleteOrganizationAndUserRoleMapping(String organizationId, String userId, String roleId, int tenantId)
+    void deleteOrganizationsUserRoleMapping(List<String> organizationIds, String userId, String roleId, int tenantId)
             throws OrganizationUserRoleMgtException;
 
     List<Role> getRolesByOrganizationAndUser(String organizationID, String userId, int tenantID)
             throws OrganizationUserRoleMgtServerException;
 
-    boolean isOrganizationAndUserRoleMappingExists(String organizationId, String userId, String roleId,
+    boolean isOrganizationUserRoleMappingExists(String organizationId, String userId, String roleId,
                                                    int tenantId)
             throws OrganizationUserRoleMgtException;
 

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/dao/OrganizationUserRoleMgtDAO.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/dao/OrganizationUserRoleMgtDAO.java
@@ -32,21 +32,22 @@ import java.util.List;
 public interface OrganizationUserRoleMgtDAO {
 
     void addOrganizationAndUserRoleMappings(List<OrganizationUserRoleMapping> organizationUserRoleMapping,
-                                            Integer tenantID)
+                                            int tenantID)
             throws OrganizationUserRoleMgtException;
 
-    List<User> getUserIdsByOrganizationAndRole(String organizationID, String roleId, Integer tenantID)
+    List<User> getUserIdsByOrganizationAndRole(String organizationID, String roleId, int offset, int limit,
+                                               List<String> requestedAttributes, int tenantID)
             throws OrganizationUserRoleMgtServerException;
 
-    void deleteOrganizationAndUserRoleMapping(String organizationId, String userId, String roleId, Integer tenantId)
+    void deleteOrganizationAndUserRoleMapping(String organizationId, String userId, String roleId, int tenantId)
             throws OrganizationUserRoleMgtException;
 
-    List<Role> getRolesByOrganizationAndUser(String organizationID, String userId, Integer tenantID)
+    List<Role> getRolesByOrganizationAndUser(String organizationID, String userId, int tenantID)
             throws OrganizationUserRoleMgtServerException;
 
     boolean isOrganizationAndUserRoleMappingExists(String organizationId, String userId, String roleId,
-                                                   Integer tenantId)
+                                                   int tenantId)
             throws OrganizationUserRoleMgtException;
 
-    Integer getRoleIdBySCIMGroupName(String roleName, Integer tenantId) throws OrganizationUserRoleMgtServerException;
+    Integer getRoleIdBySCIMGroupName(String roleName, int tenantId) throws OrganizationUserRoleMgtServerException;
 }

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/dao/OrganizationUserRoleMgtDAOImpl.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/dao/OrganizationUserRoleMgtDAOImpl.java
@@ -270,7 +270,9 @@ public class OrganizationUserRoleMgtDAOImpl implements OrganizationUserRoleMgtDA
 
         for (int i = 0; i < numberOfMapings; i++) {
             sb.append(UM_USER_ROLE_ORG_DATA);
-            sb.append(UNION_ALL);
+            if (i != numberOfMapings - 1) {
+                sb.append(UNION_ALL);
+            }
         }
         sb.append(")");
         sb.append(UPSERT_UM_USER_ROLE_ORG_END);
@@ -284,11 +286,11 @@ public class OrganizationUserRoleMgtDAOImpl implements OrganizationUserRoleMgtDA
         sb.append(AND).append("(");
         for (int i = 0; i < numberOfOrganizations; i++) {
             sb.append(ORG_ID_ADDING);
-            if(i != numberOfOrganizations-1) {
+            if (i != numberOfOrganizations - 1) {
                 sb.append(OR);
             }
         }
-        sb.append(AND).append(")");
+        sb.append(")");
         return sb.toString();
     }
 }

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/dao/OrganizationUserRoleMgtDAOImpl.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/dao/OrganizationUserRoleMgtDAOImpl.java
@@ -146,7 +146,8 @@ public class OrganizationUserRoleMgtDAOImpl implements OrganizationUserRoleMgtDA
                 Map<String, Object> attributes;
                 ObjectMapper mapper = new ObjectMapper();
                 attributes = mapper.readValue(scimResponse.getResponseMessage(),
-                        new TypeReference<Map<String, Object>>(){});
+                        new TypeReference<Map<String, Object>>() {
+                        });
                 users.add(new User(attributes));
             }
         } catch (UserStoreException | CharonException | IOException e) {

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/model/OrganizationUserRoleMapping.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/model/OrganizationUserRoleMapping.java
@@ -33,7 +33,8 @@ public class OrganizationUserRoleMapping {
 
     }
 
-    public OrganizationUserRoleMapping(String organizationId, String userId, String roleId, int hybridRoleId,  boolean cascadedRole) {
+    public OrganizationUserRoleMapping(String organizationId, String userId, String roleId, int hybridRoleId,
+                                       boolean cascadedRole) {
 
         this.organizationId = organizationId;
         this.userId = userId;

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/model/OrganizationUserRoleMapping.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/model/OrganizationUserRoleMapping.java
@@ -25,19 +25,21 @@ public class OrganizationUserRoleMapping {
 
     private String organizationId;
     private String userId;
-    private Integer hybridRoleId;
+    private int hybridRoleId;
     private String roleId;
+    private boolean cascadedRole;
 
     public OrganizationUserRoleMapping() {
 
     }
 
-    public OrganizationUserRoleMapping(String organizationId, String userId, String roleId, Integer hybridRoleId) {
+    public OrganizationUserRoleMapping(String organizationId, String userId, String roleId, int hybridRoleId,  boolean cascadedRole) {
 
         this.organizationId = organizationId;
         this.userId = userId;
         this.hybridRoleId = hybridRoleId;
         this.roleId = roleId;
+        this.cascadedRole = cascadedRole;
     }
 
     public void setOrganizationId(String organizationId) {
@@ -45,7 +47,7 @@ public class OrganizationUserRoleMapping {
         this.organizationId = organizationId;
     }
 
-    public void setHybridRoleId(Integer hybridRoleId) {
+    public void setHybridRoleId(int hybridRoleId) {
 
         this.hybridRoleId = hybridRoleId;
     }
@@ -60,6 +62,10 @@ public class OrganizationUserRoleMapping {
         this.userId = userId;
     }
 
+    public void setCascadedRole(boolean cascadedRole) {
+
+        this.cascadedRole = cascadedRole;
+    }
 
     public String getOrganizationId() {
 
@@ -71,7 +77,7 @@ public class OrganizationUserRoleMapping {
         return userId;
     }
 
-    public Integer getHybridRoleId() {
+    public int getHybridRoleId() {
 
         return hybridRoleId;
     }
@@ -79,5 +85,10 @@ public class OrganizationUserRoleMapping {
     public String getRoleId() {
 
         return roleId;
+    }
+
+    public boolean isCascadedRole() {
+
+        return cascadedRole;
     }
 }

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/model/UserRoleMapping.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/model/UserRoleMapping.java
@@ -7,13 +7,13 @@ import java.util.List;
  */
 public class UserRoleMapping {
 
-    private List<String> userIds;
+    private List<UserRoleMappingUser> users;
     private String roleId;
     private Integer hybridRoleId;
 
-    public UserRoleMapping(String roleId, List<String> userIds) {
+    public UserRoleMapping(String roleId, List<UserRoleMappingUser> users) {
         this.roleId = roleId;
-        this.userIds = userIds;
+        this.users = users;
     }
 
     public void setRoleId(String roleId) {
@@ -21,9 +21,9 @@ public class UserRoleMapping {
         this.roleId = roleId;
     }
 
-    public void setUserIds(List<String> userIds) {
+    public void setUsers(List<UserRoleMappingUser> users) {
 
-        this.userIds = userIds;
+        this.users = users;
     }
 
     public void setHybridRoleId(Integer hybridRoleId) {
@@ -36,9 +36,9 @@ public class UserRoleMapping {
         return roleId;
     }
 
-    public List<String> getUserIds() {
+    public List<UserRoleMappingUser> getUsers() {
 
-        return userIds;
+        return users;
     }
 
     public Integer getHybridRoleId() {

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/model/UserRoleMapping.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/model/UserRoleMapping.java
@@ -9,7 +9,7 @@ public class UserRoleMapping {
 
     private List<UserRoleMappingUser> users;
     private String roleId;
-    private Integer hybridRoleId;
+    private int hybridRoleId;
 
     public UserRoleMapping(String roleId, List<UserRoleMappingUser> users) {
         this.roleId = roleId;
@@ -26,7 +26,7 @@ public class UserRoleMapping {
         this.users = users;
     }
 
-    public void setHybridRoleId(Integer hybridRoleId) {
+    public void setHybridRoleId(int hybridRoleId) {
 
         this.hybridRoleId = hybridRoleId;
     }
@@ -41,7 +41,7 @@ public class UserRoleMapping {
         return users;
     }
 
-    public Integer getHybridRoleId() {
+    public int getHybridRoleId() {
 
         return hybridRoleId;
     }

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/model/UserRoleMappingUser.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/model/UserRoleMappingUser.java
@@ -18,26 +18,37 @@
 
 package org.wso2.carbon.identity.organization.user.role.mgt.core.model;
 
-import java.util.Map;
+import org.apache.axis2.databinding.types.xsd._boolean;
 
-/**
- * User representation
- */
-public class User {
+public class UserRoleMappingUser {
 
-    private Map<String, Object> userAttributes;
+    private String userId;
+    private boolean cascadedRole;
 
-    public User(Map<String, Object> attributes) {
-        this.userAttributes = attributes;
+    public UserRoleMappingUser(String userId, boolean cascadedRole) {
+
+        this.userId = userId;
+        this.cascadedRole = cascadedRole;
     }
 
-    public Map<String, Object> getUserAttributes() {
+    public void setUserId(String userId) {
 
-        return userAttributes;
+        this.userId = userId;
     }
 
-    public void setUserAttributes(Map<String, Object> userAttributes) {
+    public String getUserId() {
 
-        this.userAttributes = userAttributes;
+        return userId;
+    }
+
+    public void setCascadedRole(boolean cascadedRole) {
+
+        this.cascadedRole = cascadedRole;
+    }
+
+    public boolean isCascadedRole() {
+
+        return cascadedRole;
     }
 }
+

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/model/UserRoleMappingUser.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/model/UserRoleMappingUser.java
@@ -18,8 +18,9 @@
 
 package org.wso2.carbon.identity.organization.user.role.mgt.core.model;
 
-import org.apache.axis2.databinding.types.xsd._boolean;
-
+/**
+ * User object is UserRoleMapping.
+ */
 public class UserRoleMappingUser {
 
     private String userId;


### PR DESCRIPTION
- add caching layer to maintain child organizations of an org.
- support attribute query param when listing users for a given organization's given role.
- support includeSubOrgs property when role assignment, deletion, and new organization creation.