### PR TITLE
Fix bugs in user deletion and index out of bound issue

### DIFF
--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManager.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/OrganizationUserRoleManager.java
@@ -42,6 +42,8 @@ public interface OrganizationUserRoleManager {
     void deleteOrganizationsUserRoleMapping(String organizationId, String userId, String roleId, boolean includeSubOrgs)
             throws OrganizationUserRoleMgtException, OrganizationManagementException;
 
+    void deleteOrganizationsUserRoleMappings(String userId) throws OrganizationUserRoleMgtException;
+
     List<Role> getRolesByOrganizationAndUser(String organizationId, String userId)
             throws OrganizationUserRoleMgtException;
 

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/OrganizationUserRoleMgtConstants.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/OrganizationUserRoleMgtConstants.java
@@ -34,6 +34,8 @@ public class OrganizationUserRoleMgtConstants {
         ERROR_CODE_INVALID_ROLE_ID_ERROR("ORGPERMMGT_00002", "Invalid role id: %s"),
         ERROR_CODE_INVALID_USER_GET_REQUEST_FOR_ORG_ROLE("ORGPERMMGT_00003",
                 "Invalid users search/get request for an organization's role: %s"),
+        ERROR_CODE_INVALID_ROLE_ERROR("ORGPERMMGT_00004", "Invalid role id: %s"),
+        ERROR_CODE_NON_EXISTING_USERID_ERROR("ORGPERMMGT_00005", "No user exists with user id: %s"),
 
         // Server errors (ORGPERMMGT_00020-ORGPERMMGT_00040)
         ERROR_CODE_ORGANIZATION_USER_ROLE_MAPPINGS_ADD_ERROR("ORGPERMMGT_00020",
@@ -44,13 +46,14 @@ public class OrganizationUserRoleMgtConstants {
                 "Error while retrieving the role : %s, for user : %s for organization : %s"),
         ERROR_CODE_HYBRID_ROLE_ID_RETRIEVING_ERROR("ORGPERMMGT_00023",
                 "Error while retrieving the hybrid role id for role : %s"),
-        ERROR_CODE_INVALID_ROLE_ERROR("ORGPERMMGT_00024", "Invalid role name: %s"),
         ERROR_CODE_USERS_PER_ORG_ROLE_RETRIEVING_ERROR("ORGPERMMGT_00025",
                 "Error while retrieving users for role: %s , organization : $s"),
         ERROR_CODE_ROLES_PER_ORG_USER_RETRIEVING_ERROR("ORGPERMMGT_00026",
                 "Error while retrieving roles for user: %s , organization : $s"),
         ERROR_CODE_EVENTING_ERROR("ORGPERMMGT_00027", "Error while handling the event : %s"),
-        ERROR_CODE_USER_STORE_OPERATIONS_ERROR("ORGPERMMGT_00028", "Error accessing user store : %s");
+        ERROR_CODE_USER_STORE_OPERATIONS_ERROR("ORGPERMMGT_00028", "Error accessing user store : %s"),
+        ERROR_CODE_ORGANIZATION_USER_ROLE_MAPPINGS_DELETE_PER_USER_ERROR("ORGPERMMGT_00029",
+                "Error while deleting organization user role mappings for user : %s"),;
 
         private final String code;
         private final String message;

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/SQLConstants.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/constant/SQLConstants.java
@@ -49,6 +49,12 @@ public class SQLConstants {
                     "    UM_USER_ROLE_ORG\n" +
                     "WHERE\n" +
                     "    UM_USER_ID = ? AND UM_ROLE_ID = ? AND UM_TENANT_ID = ?";
+    public static final String DELETE_ALL_ORGANIZATION_USER_ROLE_MAPPINGS_BY_USERID =
+            "DELETE\n" +
+                    "FROM\n" +
+                    "    UM_USER_ROLE_ORG\n" +
+                    "WHERE\n" +
+                    "    UM_USER_ID = ? AND UM_TENANT_ID = ?";
     public static final String GET_ORGANIZATION_USER_ROLE_MAPPING =
             "SELECT\n" +
                     "    COUNT(1)\n" +

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/dao/OrganizationUserRoleMgtDAO.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/dao/OrganizationUserRoleMgtDAO.java
@@ -41,6 +41,8 @@ public interface OrganizationUserRoleMgtDAO {
     void deleteOrganizationsUserRoleMapping(List<String> organizationIds, String userId, String roleId, int tenantId)
             throws OrganizationUserRoleMgtException;
 
+    void deleteOrganizationsUserRoleMappings(String userId, int tenantId) throws OrganizationUserRoleMgtException;
+
     List<Role> getRolesByOrganizationAndUser(String organizationID, String userId, int tenantID)
             throws OrganizationUserRoleMgtServerException;
 

--- a/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/util/Utils.java
+++ b/org.wso2.carbon.identity.organization.user.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/user/role/mgt/core/util/Utils.java
@@ -91,12 +91,9 @@ public class Utils {
     public static UserStoreManager getUserStoreManager(int tenantId)
             throws org.wso2.carbon.user.api.UserStoreException {
 
-        UserStoreManager userStoreManager = null;
         RealmService realmService = OrganizationUserRoleMgtDataHolder.getInstance().getRealmService();
-
         UserRealm tenantUserRealm = realmService.getTenantUserRealm(tenantId);
-        userStoreManager = (UserStoreManager) tenantUserRealm.getUserStoreManager();
-
+        UserStoreManager userStoreManager = (UserStoreManager) tenantUserRealm.getUserStoreManager();
         return userStoreManager;
     }
 


### PR DESCRIPTION
- Introduce the method `deleteOrganizationsUserRoleMappings(String userId)` to delete all organization user role mappings assigned to a particular user. (Can use to delete all mappings when the user is deleted from the IS)
- Validate user existence when adding an organization user role mapping.
- Fix the index out of bounds error occurred when filtering users for an admin role.